### PR TITLE
implements 'excludes' property

### DIFF
--- a/scripts/Codenarc.groovy
+++ b/scripts/Codenarc.groovy
@@ -42,6 +42,7 @@ private void runCodenarc() {
 	   ruleSetFiles = ruleSetFiles ?:
 		     'rulesets/basic.xml,rulesets/exceptions.xml,rulesets/imports.xml,rulesets/grails.xml,rulesets/unused.xml'
 	   List includes = configureIncludes(config)
+	   List excludes = configureExcludes(config)
      boolean systemExitOnBuildException = getConfigBoolean(config, 'systemExitOnBuildException')
 
      configureCodeNarcPropertiesFile(config)
@@ -63,7 +64,7 @@ private void runCodenarc() {
                     }
                 }
             }
-            fileset(dir: '.', includes: includes.join(','))
+            fileset(dir: '.', includes: includes.join(','), excludes: excludes.join(','))
          }
     }
     catch(BuildException e) {
@@ -238,6 +239,16 @@ private List configureIncludes(config) {
     }
 
     return includes
+}
+
+private List configureExcludes(config) {
+	List excludes = []
+
+	for (exclude in config.excludes) {
+		excludes << exclude
+	}
+
+	return excludes
 }
 
 try {

--- a/test/unit/CodenarcScriptTests.groovy
+++ b/test/unit/CodenarcScriptTests.groovy
@@ -39,6 +39,7 @@ class CodenarcScriptTests extends AbstractTestCase {
     private static final TEST_INTEGRATION = 'test/integration/**/*.groovy'
     private static final VIEWS = 'grails-app/views/**/*.gsp'
     private static final DEFAULT_INCLUDES = [SRC_GROOVY, CONTROLLERS, DOMAIN, SERVICES, TAGLIB, UTILS, TEST_UNIT, TEST_INTEGRATION]
+    private static final DEFAULT_EXCLUDES = []
 
     private static final HTML = 'html'
     private static final PROPERTIES_FILE_PROP = "codenarc.properties.file"
@@ -56,6 +57,7 @@ class CodenarcScriptTests extends AbstractTestCase {
     private expectedMaxPriority3Violations
     private expectedReports
     private expectedFilesetIncludes
+    private expectedFilesetExcludes
     private expectCallToConfigSlurper = true
 
     //-------------------------------------------------------------------------
@@ -157,6 +159,14 @@ class CodenarcScriptTests extends AbstractTestCase {
         final EXTRA = ['abc', 'def/ghi']
         expectedFilesetIncludes = [SRC_GROOVY, CONTROLLERS, DOMAIN, TEST_UNIT, 'abc/**/*.groovy', 'def/ghi/**/*.groovy']
         def codeNarcConfig = [processServices:false, processTaglib:false, processUtils:false, processTestIntegration:false, extraIncludeDirs:EXTRA]
+        testRun(codeNarcConfig)
+    }
+    
+    void testRun_Excludes() {
+        final EXCLUDES = ['**/abc*.groovy', '**/def*.groovy']
+        expectedFilesetExcludes = ['**/abc*.groovy', '**/def*.groovy']
+        expectedFilesetIncludes = DEFAULT_INCLUDES
+        def codeNarcConfig = [excludes:EXCLUDES]
         testRun(codeNarcConfig)
     }
 
@@ -296,7 +306,7 @@ class CodenarcScriptTests extends AbstractTestCase {
             }
             codeNarcAntTask.demand.fileset { args ->
                 println "fileset properties=$args"
-                assert args == [dir:FILESET_DIR, includes:expectedFilesetIncludes.join(',')]
+                assert args == [dir:FILESET_DIR, includes:expectedFilesetIncludes.join(','), excludes:expectedFilesetExcludes.join(',')]
             }
 
             def codeNarcAntTaskProxy = codeNarcAntTask.proxyInstance()
@@ -368,6 +378,7 @@ class CodenarcScriptTests extends AbstractTestCase {
         expectedMaxPriority2Violations = MAX
         expectedMaxPriority3Violations = MAX
         expectedFilesetIncludes = DEFAULT_INCLUDES
+        expectedFilesetExcludes = DEFAULT_EXCLUDES
         expectedReports = [ [type:HTML, outputFile:REPORT_FILE, title:''] ]
     }
 


### PR DESCRIPTION
These changes adds 'excludes' property that can be declared in BuildConfig.groovy.

Usage:

```
codenarc.excludes = [
    '**/Dummy*.groovy',
    'grails-app/taglib/**/Some*TagLib.groovy'
]
```

There is a difference in the implementation of 'extraIncludeDirs' and 'excludes'.
One specifies directories, the other specifies paths.
Considering affinity to ant task, I think it's better.

Or, we may need to also implement 'includes' property.

Such as:

```
codenarc.includes = [
    'grails-app/taglib/**/Some*ExceptThisTagLib.groovy'
]
```
