### PR TITLE
Updated the dependency of CodeNarc to v0.22

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -11,7 +11,7 @@ grails.project.dependency.resolution = {
 	}
 
 	dependencies {
-		compile "org.codenarc:CodeNarc:0.21", {
+		compile "org.codenarc:CodeNarc:0.22", {
 			excludes "log4j", "groovy-all", "ant"
 		}
 	}


### PR DESCRIPTION
Since CodeNarc v0.22 introduced a bunch of new checks which I'd
like to use in grails-projects as well I've upgraded the dependency
to the current CodeNarc version. Compilation with Grails 2.1.2
was successful as well as the execution of the contained tests.
